### PR TITLE
Add image alts to each dcd event sponsor

### DIFF
--- a/src/cljc/dcd_website/dcd2017.cljc
+++ b/src/cljc/dcd_website/dcd2017.cljc
@@ -18,16 +18,16 @@
    [:p "DCD is a free event that is made possible thanks to our amazing sponsors and volunteers."]
    [:h2.platinum "Platinum sponsors"]
    [:a.sponsor {:href "http://www.adgoji.com/" :target :_blank}
-    [:img {:src "img/sponsors/adgoji.svg"}]]
+    [:img {:src "img/sponsors/adgoji.svg" :alt "adgoji"}]]
    [:a.sponsor {:href "http://www.vakantiediscounter.nl/" :target :_blank}
-    [:img {:src "img/sponsors/elmar.svg"}]]
+    [:img {:src "img/sponsors/elmar.svg" :alt "VakantieDiscounter"}]]
    [:h2.regular "Silver sponsors"]
    [:a.sponsor.juxt {:href "https://juxt.pro/" :target :_blank}
-    [:img {:src "img/sponsors/juxt.svg"}]]
+    [:img {:src "img/sponsors/juxt.svg" :alt "JUXT"}]]
    [:a.sponsor.infi {:href "https://infi.nl/" :target :_blank}
-    [:img {:src "img/sponsors/infi.svg"}]]
+    [:img {:src "img/sponsors/infi.svg" :alt "Infi"}]]
    [:a.sponsor.lunatech {:href "http://lunatech.com/" :target :_blank}
-    [:img {:src "img/sponsors/lunatech.svg"}]]
+    [:img {:src "img/sponsors/lunatech.svg" :alt "Lunatech"}]]
    [:p "If you are interested in sponsoring this event please contact us via "
     [:a {:href "mailto:events@clojuredays.org"}
      "email."]]])

--- a/src/cljc/dcd_website/dcd2018.cljc
+++ b/src/cljc/dcd_website/dcd2018.cljc
@@ -13,25 +13,25 @@
    [:p "DCD is a free event that is made possible thanks to our amazing sponsors and volunteers."]
    [:h2.platinum "Platinum sponsors"]
    [:a.sponsor.platinum {:href "http://www.adgoji.com/" :target :_blank}
-    [:img {:src "img/2018/sponsors/adgoji.svg"}]]
+    [:img {:src "img/2018/sponsors/adgoji.svg" :alt "adgoji"}]]
    [:a.sponsor.platinum {:href "http://www.metosin.fi/en" :target :_blank}
-    [:img {:src "img/2018/sponsors/metosin.svg"}]]
+    [:img {:src "img/2018/sponsors/metosin.svg" :alt "Metosin"}]]
    [:a.sponsor.platinum {:href "https://www.exoscale.ch/" :target :_blank}
-    [:img {:src "img/2018/sponsors/exoscale.svg"}]]
+    [:img {:src "img/2018/sponsors/exoscale.svg" :alt "Exoscale"}]]
    [:a.sponsor.platinum {:href "https://synple.eu/en/index" :target :_blank}
-    [:img {:src "img/2018/sponsors/synple.png"}]]
+    [:img {:src "img/2018/sponsors/synple.png" :alt "Synple"}]]
    [:a.sponsor.platinum {:href "https://vakantiediscounter.nl" :target :_blank}
-    [:img {:src "img/2018/sponsors/otravo.svg"}]]
+    [:img {:src "img/2018/sponsors/otravo.svg" :alt "VakantieDiscounter"}]]
 
    [:h2.regular "Regular Sponsors"]
    [:a.sponsor.regular.infi {:href "https://infi.nl/" :target :_blank}
-    [:img {:src "img/2018/sponsors/infi.svg"}]]
+    [:img {:src "img/2018/sponsors/infi.svg" :alt "Infi"}]]
    [:a.sponsor.regular {:href "https://www.brightin.nl/" :target :_blank}
-    [:img {:src "img/2018/sponsors/brightin.png"}]]
+    [:img {:src "img/2018/sponsors/brightin.png" :alt "Brightin"}]]
    [:a.sponsor.regular.alliander {:href "https://www.alliander.com/en" :target :_blank}
-    [:img {:src "img/2018/sponsors/alliander.png"}]]
+    [:img {:src "img/2018/sponsors/alliander.png" :alt "Alliander"}]]
    [:a.sponsor.regular.digitalechecklisten {:href "https://digitalechecklisten.nl/" :target :_blank}
-    [:img {:src "img/2018/sponsors/digitalechecklisten.png"}]]])
+    [:img {:src "img/2018/sponsors/digitalechecklisten.png" :alt "Digitale Checklisten"}]]])
 
 (defn tickets-component []
   [:div#date

--- a/src/cljc/dcd_website/dcd2019.cljc
+++ b/src/cljc/dcd_website/dcd2019.cljc
@@ -23,25 +23,25 @@
   [:div.sponsors
    [:p "DCD is a free event that is made possible thanks to our amazing sponsors and volunteers."]
    [:a.sponsor.platinum {:href "https://flexiana.com/" :target :_blank}
-    [:img {:src "img/2019/sponsors/flexiana.jpg"}]]
+    [:img {:src "img/2019/sponsors/flexiana.jpg" :alt "Flexiana"}]]
    [:a.sponsor.regular {:href "http://www.adgoji.com/" :target :_blank}
-    [:img {:src "img/2019/sponsors/adgoji.svg"}]]
+    [:img {:src "img/2019/sponsors/adgoji.svg" :alt "adgoji"}]]
    [:a.sponsor.regular {:href "http://www.metosin.fi/en" :target :_blank}
-    [:img {:src "img/2019/sponsors/metosin.svg"}]]
+    [:img {:src "img/2019/sponsors/metosin.svg" :alt "Metosin"}]]
    [:a.sponsor.regular {:href "https://www.exoscale.ch/" :target :_blank}
-    [:img {:src "img/2019/sponsors/exoscale.svg"}]]
+    [:img {:src "img/2019/sponsors/exoscale.svg" :alt "Exoscale"}]]
    [:a.sponsor.regular {:href "https://vakantiediscounter.nl" :target :_blank}
-    [:img {:src "img/2019/sponsors/devakantiediscounter.svg"}]]
+    [:img {:src "img/2019/sponsors/devakantiediscounter.svg" :alt "VakantieDiscounter"}]]
    [:a.sponsor.regular {:href "https://infi.nl/" :target :_blank}
-    [:img {:src "img/2019/sponsors/infi.svg"}]]
+    [:img {:src "img/2019/sponsors/infi.svg" :alt "Infi"}]]
    [:a.sponsor.regular {:href "https://lunatech.com/" :target :_blank}
-    [:img {:src "img/2019/sponsors/lunatech.svg"}]]
+    [:img {:src "img/2019/sponsors/lunatech.svg" :alt "Lunatech"}]]
    [:a.sponsor.regular {:href "https://nedap.com" :target :_blank}
-    [:img {:src "img/2019/sponsors/nedap.png"}]]
+    [:img {:src "img/2019/sponsors/nedap.png" :alt "Nedap"}]]
    [:a.sponsor.regular {:href "https://data42.de" :target :_blank}
-    [:img {:src "img/2019/sponsors/data42.svg"}]]
+    [:img {:src "img/2019/sponsors/data42.svg" :alt "data42"}]]
    [:a.sponsor.regular {:href "https://cognitect.com" :target :_blank}
-    [:img {:src "img/2019/sponsors/cognitect.svg"}]]])
+    [:img {:src "img/2019/sponsors/cognitect.svg" :alt "Cognitect"}]]])
 
 (defn tickets-component []
   [:div#date

--- a/src/cljc/dcd_website/dcd2020.cljc
+++ b/src/cljc/dcd_website/dcd2020.cljc
@@ -70,26 +70,26 @@ later time. Stay tuned for news and make sure to follow us on twitter."]
     [:p "DCD is a free event that is made possible thanks to our amazing sponsors and volunteers."]
     [:h3.package "Partner"]
     [:a.sponsor.platinum {:href "https://www.greenhousegroup.com/" :target :_blank}
-     [:img {:src "img/2020/sponsors/ghg.png"}]]
+     [:img {:src "img/2020/sponsors/ghg.png" :alt "Greenhouse Group"}]]
     [:h3.package "Sponsor"]
     [:a.sponsor.regular {:href "http://www.adgoji.com/" :target :_blank}
-     [:img {:src "img/2019/sponsors/adgoji.svg"}]]
+     [:img {:src "img/2019/sponsors/adgoji.svg" :alt "adgoji"}]]
     [:a.sponsor.regular {:href "https://cognitect.com" :target :_blank}
-     [:img {:src "img/2019/sponsors/cognitect.svg"}]]
+     [:img {:src "img/2019/sponsors/cognitect.svg" :alt "Cognitect"}]]
     [:a.sponsor.regular {:href "https://www.magnet.coop/" :target :_blank}
-     [:img {:src "img/2020/sponsors/magnet.svg"}]]
+     [:img {:src "img/2020/sponsors/magnet.svg" :alt "Magnet"}]]
     [:a.sponsor.regular {:href "https://twitter.com/iarenaza" :target :_blank}
-     [:img {:src "img/2020/sponsors/ian.svg"}]]
+     [:img {:src "img/2020/sponsors/ian.svg" :alt "Iñaki Arenaza"}]]
     [:a.sponsor.regular {:href "https://www.brightin.nl/" :target :_blank}
-     [:img {:src "img/2018/sponsors/brightin.png"}]]
+     [:img {:src "img/2018/sponsors/brightin.png" :alt "Brightin"}]]
     [:a.sponsor.regular {:href "https://vakantiediscounter.nl" :target :_blank}
-     [:img {:src "img/2019/sponsors/devakantiediscounter.svg"}]]
+     [:img {:src "img/2019/sponsors/devakantiediscounter.svg" :alt "VakantieDiscounter"}]]
     [:a.sponsor.regular {:href "https://flexiana.com/" :target :_blank}
-     [:img {:src "img/2019/sponsors/flexiana.jpg"}]]
+     [:img {:src "img/2019/sponsors/flexiana.jpg" :alt "Flexiana"}]]
     [:a.sponsor.regular {:href "https://infi.nl/" :target :_blank}
-     [:img {:src "img/2019/sponsors/infi.svg"}]]
+     [:img {:src "img/2019/sponsors/infi.svg" :alt "Infi"}]]
     [:a.sponsor.regular {:href "https://lunatech.com/" :target :_blank}
-     [:img {:src "img/2019/sponsors/lunatech.svg"}]]]])
+     [:img {:src "img/2019/sponsors/lunatech.svg" :alt "Lunatech"}]]]])
 
 (defn main-component []
   [:article.main

--- a/src/cljc/dcd_website/dcd2022.cljc
+++ b/src/cljc/dcd_website/dcd2022.cljc
@@ -56,23 +56,23 @@
     [:p "DCD is a free event that is made possible thanks to our amazing sponsors and volunteers."]
     [:h3.package "Partner"]
     [:a.sponsor.platinum {:href "https://www.brightmotive.com/company/careers/" :target :_blank}
-     [:img {:src "img/2022/sponsors/brightmotive.svg"}]]
+     [:img {:src "img/2022/sponsors/brightmotive.svg" :alt "Brightmotive"}]]
     [:a.sponsor.platinum {:href "https://juxt.pro" :target :_blank}
-     [:img {:src "img/2022/sponsors/juxt.svg"}]]
+     [:img {:src "img/2022/sponsors/juxt.svg" :alt "JUXT"}]]
     [:a.sponsor.platinum {:href "https://flexiana.com/" :target :_blank}
-     [:img {:src "img/2022/sponsors/flexiana.png"}]]
+     [:img {:src "img/2022/sponsors/flexiana.png" :alt "Flexiana"}]]
     [:a.sponsor.platinum {:href "https://freshcodeit.com/services/clojure-development-company" :target :_blank}
-     [:img {:src "img/2022/sponsors/freshcode.svg"}]]
+     [:img {:src "img/2022/sponsors/freshcode.svg" :alt "Freshcode"}]]
     [:h3.package "Sponsor"]
     [:a.sponsor.regular {:href "https://www.eerlijkewoz.nl/" :target :_blank}
-     [:img {:src "img/2022/sponsors/eerlijkewoz.svg"}]]
+     [:img {:src "img/2022/sponsors/eerlijkewoz.svg" :alt "Eerlijke WOZ"}]]
     [:a.sponsor.regular {:href "https://adgoji.bamboohr.com/jobs/" :target :_blank}
-     [:img {:src "img/2022/sponsors/adgoji.png"}]]
+     [:img {:src "img/2022/sponsors/adgoji.png" :alt "adgoji"}]]
     [:a.sponsor.regular {:href "https://www.metosin.fi/en/" :target :_blank}
-     [:img {:src "img/2022/sponsors/metosin.svg"}]]
+     [:img {:src "img/2022/sponsors/metosin.svg" :alt "Metosin"}]]
     [:h3.package "Friends and family"]
     [:a.sponsor.regular {:href "https://www.cloudpirates.nl/" :target :_blank}
-     [:img {:src "img/2022/sponsors/cloudpirates.png"}]]]])
+     [:img {:src "img/2022/sponsors/cloudpirates.png" :alt "Cloud Pirates"}]]]])
 
 (def agenda-data
   [{:time ["8:30" "9:15"]


### PR DESCRIPTION
Hi team,

I've added an image alt to each sponsor on each of the dcd events.

Just in case an image fails, it will still show the name
and it adds an additional datapoint for our little Skyscraper trial to grab.

I've used each sponsors website where possible to stay as close to there naming.
For each company that has their name in CAPITALS, I searched around to make sure that
is how they use that name.. turns out, many don't.